### PR TITLE
Upgrade to latest uniffi (0.23.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           lfs: true
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: '17'
           cache: 'gradle'
           # Reference: https://github.com/mozilla/rust-android-gradle/blob/master/.github/workflows/check.yml
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v2
-      - uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r21e
       - uses: actions-rs/toolchain@v1
         # Reference: https://github.com/rust-windowing/android-ndk-rs/blob/master/.github/workflows/rust.yml
         with:
@@ -54,8 +49,5 @@ jobs:
         run: |
           make prepare-android
       - name: "Build Android library"
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: |
-          cd hello
-          make android
+        run: make android
+        working-directory: hello

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ prepare-apple:
 	rustup toolchain install nightly
 	rustup target add aarch64-apple-ios-sim --toolchain nightly && rustup target add aarch64-apple-ios x86_64-apple-ios
 	rustup component add rust-src --toolchain nightly
-	make install-uniffi-bindgen
 
 prepare-android:
 	rustup toolchain install stable
@@ -12,7 +11,3 @@ prepare-android:
 	rustup target add aarch64-linux-android
 	rustup target add armv7-linux-androideabi
 	rustup target add i686-linux-android
-	make install-uniffi-bindgen
-
-install-uniffi-bindgen:
-	cargo install uniffi_bindgen --version 0.17.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please read <https://www.rust-lang.org/tools/install>.
 
 ### iOS
 
-1. Latest Xcode (13.x)
+1. Latest Xcode (14.3)
 1. Rust toolchains for iOS: `make prepare-apple` or `rustup target add aarch64-apple-ios-sim --toolchain nightly && rustup target add aarch64-apple-ios x86_64-apple-ios`. Check installaion:
     ```shell
     $ rustup target list --installed | grep ios

--- a/hello/Cargo.toml
+++ b/hello/Cargo.toml
@@ -8,14 +8,18 @@ version = "0.1.0"
 crate-type = ["staticlib", "cdylib"]
 name = "hello"
 
+[[bin]]
+name = "uniffi-bindgen"
+path = "bin/uniffi-bindgen.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uniffi = "0.22.0"
-uniffi_macros = "0.22.0"
+uniffi = "0.23.0"
+uniffi_macros = "0.23.0"
 
 [build-dependencies]
-uniffi_build = "0.22.0"
+uniffi = { version = "0.23.0", features = [ "build" ] }
 
 [profile.release]
 codegen-units = 1 # Reduce number of codegen units to increase optimizations.

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -8,18 +8,18 @@ apple:
 	@make cp-xcframeowrk-source
 
 build-targets:
-	cargo build --release --target x86_64-apple-ios
-	cargo +nightly build --release --target aarch64-apple-ios-sim
-	cargo +nightly build -Z build-std --release --target aarch64-apple-ios-macabi
-	cargo +nightly build -Z build-std --release --target x86_64-apple-ios-macabi
-	cargo build --release --target aarch64-apple-ios
+	cargo build --lib --release --target x86_64-apple-ios
+	cargo +nightly build --lib --release --target aarch64-apple-ios-sim
+	cargo +nightly build -Z build-std --lib --release --target aarch64-apple-ios-macabi
+	cargo +nightly build -Z build-std --lib --release --target x86_64-apple-ios-macabi
+	cargo build --lib --release --target aarch64-apple-ios
 
 bindgen-swift:
-	uniffi-bindgen generate src/hello.udl --language swift
+	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/hello.udl --language swift
 	sed -i '' 's/module\ HelloFFI/framework\ module\ HelloFFI/' src/HelloFFI.modulemap
 
 bindgen-kotlin:
-	uniffi-bindgen generate src/hello.udl --language kotlin -o platforms/android/UniffiRustExample/app/src/main/java
+	cargo run --features=uniffi/cli --bin uniffi-bindgen generate src/hello.udl --language kotlin -o platforms/android/UniffiRustExample/app/src/main/java
 	sed -i '' 's/return "uniffi_Hello"/return "hello"/' platforms/android/UniffiRustExample/app/src/main/java/uniffi/Hello/Hello.kt
 
 assemble-frameworks:

--- a/hello/bin/uniffi-bindgen.rs
+++ b/hello/bin/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/hello/build.rs
+++ b/hello/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  uniffi_build::generate_scaffolding("./src/hello.udl").unwrap();
+  uniffi::generate_scaffolding("./src/hello.udl").unwrap();
 }

--- a/hello/platforms/android/UniffiRustExample/app/build.gradle
+++ b/hello/platforms/android/UniffiRustExample/app/build.gradle
@@ -15,7 +15,7 @@ cargo {
 
 android {
     compileSdk 31
-//    ndkVersion rootProject.ext.ndkVersion
+    ndkVersion "25.2.9519653"
 
     defaultConfig {
         applicationId "com.demo.mobile.uniffirustexample"
@@ -43,6 +43,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'com.example.mobile.demo.uniffirustexample'
 }
 
 dependencies {

--- a/hello/platforms/android/UniffiRustExample/app/build.gradle
+++ b/hello/platforms/android/UniffiRustExample/app/build.gradle
@@ -10,6 +10,7 @@ cargo {
     module = "../../../.."       // Or whatever directory contains your Cargo.toml
     libname = "hello"          // Or whatever matches Cargo.toml's [package] name.
     targets = ["arm", "x86", "x86_64", "arm64"]
+    extraCargoBuildArguments = ["--lib"]
 }
 
 android {

--- a/hello/platforms/android/UniffiRustExample/app/src/main/AndroidManifest.xml
+++ b/hello/platforms/android/UniffiRustExample/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.mobile.demo.uniffirustexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"

--- a/hello/platforms/android/UniffiRustExample/build.gradle
+++ b/hello/platforms/android/UniffiRustExample/build.gradle
@@ -8,9 +8,9 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.5.30' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
     id "org.mozilla.rust-android-gradle.rust-android" version "0.9.2"
 
 }

--- a/hello/platforms/android/UniffiRustExample/gradle.properties
+++ b/hello/platforms/android/UniffiRustExample/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/hello/platforms/android/UniffiRustExample/gradle/wrapper/gradle-wrapper.properties
+++ b/hello/platforms/android/UniffiRustExample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 07 11:58:42 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/hello/platforms/apple/Hello/Package.swift
+++ b/hello/platforms/apple/Hello/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Hello",
-            dependencies: []
+            dependencies: ["HelloFFI"]
         ),
          .binaryTarget(name: "HelloFFI", path: "Sources/HelloFFI.xcframework"),
         .testTarget(


### PR DESCRIPTION
Changes: 

1. `uniffi_bindgen` in 0.23.0 no longer provides a standalone binary.
2. Add `uniffi-bindgen.rs` and `--lib` build arg
3. Add explicit `HelloFFI` dependency to target `Hello`